### PR TITLE
C++ node rescue throw Fault exception

### DIFF
--- a/src/ros_comm/rosmaster/src/rosmaster/rosrescue.py
+++ b/src/ros_comm/rosmaster/src/rosmaster/rosrescue.py
@@ -124,7 +124,7 @@ class RosRescue(object):
                 if not uriValidate[0] or not uriValidate[1]:
                     return None
                 proxy = ServerProxy(uri)
-                proxy.getName("/master")
+                proxy.getPid("/master")
                 live_nodes[caller_id] = proxy
                 #print("live node : "+ caller_id)
             except Fault as e:


### PR DESCRIPTION
The node wrote by c++ would throw a Fault exception, then I checked c++ version xmlrpc, which did not implement a getName method function. But [getPid](https://github.com/PushyamiKaveti/fault-tolerant-ros-master/blob/master/src/ros_comm/roscpp/src/libros/xmlrpc_manager.cpp#L120) is fine, and same role in this function.